### PR TITLE
Integracion continua con TravisCI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,10 @@
+language: java
+sudo: false
+
+install: true
+
+before_script:
+  - cd PICO
+  
+script:
+  - mvn install -DskipTests=true -Dmaven.javadoc.skip=true -B -V


### PR DESCRIPTION
Activar integración continua usando TravisCI, con esto se puede validar que todos los commits al proyecto se integren sin errores de compilación y en un futuro ejecutar pruebas unitarias cuando se agregen al proyecto.